### PR TITLE
Implement Zustand state management

### DIFF
--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -1,38 +1,12 @@
-import ChannelList, { type Channel } from "./ChannelList";
+import ChannelList from "./ChannelList";
 import GroupList from "./GroupList";
-import type { Tab } from "./NavigationSidebar";
-
-enum GroupDisplayMode {
-  EnabledGroups = 'enabled',
-  AllGroups = 'all'
-}
-
-interface MainContentProps {
-  activeTab: Tab;
-  channelListName: string;
-  searchQuery: string;
-  isSearching: boolean;
-  filteredChannels: Channel[];
-  favorites: Channel[];
-  groups: string[];
-  history: Channel[];
-  selectedGroup: string | null;
-  selectedChannel: Channel | null;
-  focusedIndex: number;
-  enabledGroups: Set<string>;
-  groupDisplayMode: GroupDisplayMode;
-  isLoadingChannelList: boolean;
-  onSearch: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  onClearSearch: () => void;
-  onSelectChannel: (channel: Channel) => void;
-  onToggleFavorite: (channel: Channel) => void;
-  onSelectGroup: (group: string | null) => void;
-  onToggleGroupEnabled: (group: string) => void;
-  onChangeDisplayMode: (mode: GroupDisplayMode) => void;
-  onSelectAllGroups: () => void;
-  onUnselectAllGroups: () => void;
-  onClearGroupFilter: () => void;
-}
+import { useChannelListName } from "../hooks/useChannelListName";
+import { 
+  useChannelStore,
+  useUIStore,
+  useGroupStore,
+  useUserDataStore
+} from "../stores";
 
 // Loading indicator component
 const LoadingChannelList = () => (
@@ -47,32 +21,70 @@ const LoadingChannelList = () => (
   </div>
 );
 
-export default function MainContent({
-  activeTab,
-  channelListName,
-  searchQuery,
-  isSearching,
-  filteredChannels,
-  favorites,
-  groups,
-  history,
-  selectedGroup,
-  selectedChannel,
-  focusedIndex,
-  enabledGroups,
-  groupDisplayMode,
-  isLoadingChannelList,
-  onSearch,
-  onClearSearch,
-  onSelectChannel,
-  onToggleFavorite,
-  onSelectGroup,
-  onToggleGroupEnabled,
-  onChangeDisplayMode,
-  onSelectAllGroups,
-  onUnselectAllGroups,
-  onClearGroupFilter
-}: MainContentProps) {
+export default function MainContent() {
+  // Get state from stores
+  const { 
+    filteredChannels, 
+    selectedChannel, 
+    selectedChannelListId,
+    setSelectedChannel 
+  } = useChannelStore();
+  
+  const {
+    activeTab,
+    focusedIndex,
+    isLoadingChannelList,
+    searchQuery,
+    isSearching,
+    setSearchQuery
+  } = useUIStore();
+  
+  const {
+    groups,
+    selectedGroup,
+    enabledGroups,
+    groupDisplayMode,
+    setSelectedGroup,
+    setGroupDisplayMode,
+    toggleGroupEnabled,
+    selectAllGroups,
+    unselectAllGroups,
+    clearGroupFilter
+  } = useGroupStore();
+  
+  const {
+    favorites,
+    history,
+    toggleFavorite
+  } = useUserDataStore();
+  
+  // Hooks
+  const channelListName = useChannelListName(selectedChannelListId);
+
+  const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchQuery(e.target.value);
+  };
+
+  const handleClearSearch = () => {
+    setSearchQuery("");
+  };
+
+  const handleToggleGroupEnabled = (group: string) => {
+    toggleGroupEnabled(group);
+  };
+
+  const handleSelectAllGroups = () => {
+    selectAllGroups();
+  };
+
+  const handleUnselectAllGroups = () => {
+    unselectAllGroups();
+  };
+
+  const handleClearGroupFilter = () => {
+    clearGroupFilter();
+  };
+
   const getTabTitle = () => {
     switch (activeTab) {
       case "channels":
@@ -124,12 +136,12 @@ export default function MainContent({
                   className="search-input"
                   placeholder="Search channels (min 3 characters)..."
                   value={searchQuery}
-                  onChange={onSearch}
+                  onChange={handleSearch}
                 />
                 {searchQuery && (
                   <button
                     className="clear-search-btn"
-                    onClick={onClearSearch}
+                    onClick={handleClearSearch}
                     type="button"
                     title="Clear search"
                   >
@@ -155,9 +167,9 @@ export default function MainContent({
                 focusedIndex={focusedIndex}
                 favorites={favorites}
                 selectedGroup={selectedGroup}
-                onSelectChannel={onSelectChannel}
-                onToggleFavorite={onToggleFavorite}
-                onClearGroupFilter={onClearGroupFilter}
+                onSelectChannel={(channel) => setSelectedChannel(channel)}
+                onToggleFavorite={(channel) => toggleFavorite(channel)}
+                onClearGroupFilter={handleClearGroupFilter}
               />
             </div>
           </>
@@ -171,9 +183,9 @@ export default function MainContent({
               focusedIndex={focusedIndex}
               favorites={favorites}
               selectedGroup={selectedGroup}
-              onSelectChannel={onSelectChannel}
-              onToggleFavorite={onToggleFavorite}
-              onClearGroupFilter={onClearGroupFilter}
+              onSelectChannel={(channel) => setSelectedChannel(channel)}
+              onToggleFavorite={(channel) => toggleFavorite(channel)}
+              onClearGroupFilter={handleClearGroupFilter}
             />
           </div>
         );
@@ -186,11 +198,11 @@ export default function MainContent({
               focusedIndex={focusedIndex}
               enabledGroups={enabledGroups}
               groupDisplayMode={groupDisplayMode}
-              onSelectGroup={onSelectGroup}
-              onToggleGroupEnabled={onToggleGroupEnabled}
-              onChangeDisplayMode={onChangeDisplayMode}
-              onSelectAllGroups={onSelectAllGroups}
-              onUnselectAllGroups={onUnselectAllGroups}
+              onSelectGroup={(group) => setSelectedGroup(group)}
+              onToggleGroupEnabled={(group) => handleToggleGroupEnabled(group)}
+              onChangeDisplayMode={(mode) => setGroupDisplayMode(mode)}
+              onSelectAllGroups={handleSelectAllGroups}
+              onUnselectAllGroups={handleUnselectAllGroups}
             />
           </div>
         );
@@ -203,9 +215,9 @@ export default function MainContent({
               focusedIndex={focusedIndex}
               favorites={favorites}
               selectedGroup={selectedGroup}
-              onSelectChannel={onSelectChannel}
-              onToggleFavorite={onToggleFavorite}
-              onClearGroupFilter={onClearGroupFilter}
+              onSelectChannel={(channel) => setSelectedChannel(channel)}
+              onToggleFavorite={(channel) => toggleFavorite(channel)}
+              onClearGroupFilter={handleClearGroupFilter}
             />
           </div>
         );

--- a/src/components/NavigationSidebar.tsx
+++ b/src/components/NavigationSidebar.tsx
@@ -1,22 +1,41 @@
 import { TvIcon, HeartIcon, UsersIcon, HistoryIcon, SettingsIcon } from "./Icons";
 import SavedFilters from "./SavedFilters";
-import type { SavedFilter } from "../hooks/useSavedFilters";
+import { useUIStore, useGroupStore, GroupDisplayMode } from "../stores";
+import { useSavedFilters, type SavedFilter } from "../hooks/useSavedFilters";
+import { useChannelStore } from "../stores";
 
 type Tab = "channels" | "favorites" | "groups" | "history" | "settings";
 
-interface NavigationSidebarProps {
-  activeTab: Tab;
-  onTabChange: (tab: Tab) => void;
-  savedFilters: SavedFilter[];
-  onApplyFilter: (filter: SavedFilter) => void;
-}
+export default function NavigationSidebar() {
+  const { activeTab, setActiveTab, setFocusedIndex, setSearchQuery } = useUIStore();
+  const { setSelectedGroup, setGroupDisplayMode } = useGroupStore();
+  const { selectedChannelListId } = useChannelStore();
+  const { savedFilters } = useSavedFilters(selectedChannelListId);
 
-export default function NavigationSidebar({ 
-  activeTab, 
-  onTabChange, 
-  savedFilters, 
-  onApplyFilter
-}: NavigationSidebarProps) {
+  const handleTabChange = (tab: Tab) => {
+    setActiveTab(tab);
+  };
+
+  const handleApplyFilter = (filter: SavedFilter) => {
+    // Apply the search query
+    setSearchQuery(filter.search_query);
+    
+    // Apply the group selection and set appropriate display mode
+    setSelectedGroup(filter.selected_group);
+    
+    // If the filter has a selected group, switch to AllGroups mode to make the group filter active
+    // If no group is selected, use EnabledGroups mode
+    if (filter.selected_group) {
+      setGroupDisplayMode(GroupDisplayMode.AllGroups);
+    } else {
+      setGroupDisplayMode(GroupDisplayMode.EnabledGroups);
+    }
+    
+    // Switch to channels tab to see the results
+    setActiveTab("channels");
+    setFocusedIndex(0);
+  };
+
   return (
     <div className="nav-sidebar">
       <div className="app-header">
@@ -27,35 +46,35 @@ export default function NavigationSidebar({
         <nav className="nav-menu">
           <button 
             className={`nav-button ${activeTab === "channels" ? "active" : ""}`}
-            onClick={() => onTabChange("channels")}
+            onClick={() => handleTabChange("channels")}
           >
             <TvIcon />
             Channels
           </button>
           <button 
             className={`nav-button ${activeTab === "favorites" ? "active" : ""}`}
-            onClick={() => onTabChange("favorites")}
+            onClick={() => handleTabChange("favorites")}
           >
             <HeartIcon />
             Favorites
           </button>
           <button 
             className={`nav-button ${activeTab === "groups" ? "active" : ""}`}
-            onClick={() => onTabChange("groups")}
+            onClick={() => handleTabChange("groups")}
           >
             <UsersIcon />
             Groups
           </button>
           <button 
             className={`nav-button ${activeTab === "history" ? "active" : ""}`}
-            onClick={() => onTabChange("history")}
+            onClick={() => handleTabChange("history")}
           >
             <HistoryIcon />
             History
           </button>
           <button 
             className={`nav-button ${activeTab === "settings" ? "active" : ""}`}
-            onClick={() => onTabChange("settings")}
+            onClick={() => handleTabChange("settings")}
           >
             <SettingsIcon />
             Settings
@@ -64,7 +83,7 @@ export default function NavigationSidebar({
       </div>
       <SavedFilters 
         savedFilters={savedFilters}
-        onApplyFilter={onApplyFilter}
+        onApplyFilter={handleApplyFilter}
       />
     </div>
   );

--- a/src/hooks/useChannelSearch.ts
+++ b/src/hooks/useChannelSearch.ts
@@ -1,11 +1,17 @@
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import type { Channel } from "../components/ChannelList";
+import { useUIStore } from "../stores";
 
 export function useChannelSearch(selectedChannelListId: number | null) {
-  const [searchQuery, setSearchQuery] = useState("");
-  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("");
-  const [isSearching, setIsSearching] = useState(false);
+  const {
+    searchQuery,
+    debouncedSearchQuery,
+    isSearching,
+    setSearchQuery,
+    setDebouncedSearchQuery,
+    setIsSearching
+  } = useUIStore();
 
   // Debounce search query
   useEffect(() => {
@@ -14,7 +20,7 @@ export function useChannelSearch(selectedChannelListId: number | null) {
     }, 400);
 
     return () => clearTimeout(timer);
-  }, [searchQuery]);
+  }, [searchQuery, setDebouncedSearchQuery]);
 
   const searchChannels = async (query: string): Promise<Channel[]> => {
     if (query === "" || query.length < 3) {

--- a/src/stores/channelStore.ts
+++ b/src/stores/channelStore.ts
@@ -1,0 +1,74 @@
+import { create } from 'zustand';
+import { invoke } from '@tauri-apps/api/core';
+import type { Channel } from '../components/ChannelList';
+
+interface ChannelList {
+  id: number;
+  name: string;
+  source: string;
+  is_default: boolean;
+  last_fetched: number | null;
+}
+
+interface ChannelState {
+  // State
+  channels: Channel[];
+  selectedChannel: Channel | null;
+  selectedChannelListId: number | null;
+  channelLists: ChannelList[];
+  filteredChannels: Channel[];
+  
+  // Actions
+  setChannels: (channels: Channel[]) => void;
+  setSelectedChannel: (channel: Channel | null) => void;
+  setSelectedChannelListId: (id: number | null) => void;
+  setChannelLists: (lists: ChannelList[]) => void;
+  setFilteredChannels: (channels: Channel[]) => void;
+  
+  // Async actions
+  fetchChannels: (id?: number | null) => Promise<void>;
+  fetchChannelLists: () => Promise<void>;
+  loadDefaultChannelList: () => Promise<void>;
+  syncGroupsForChannelList: (channelListId: number, allGroups: string[]) => Promise<void>;
+}
+
+const useChannelStore = create<ChannelState>((set, get) => ({
+  // Initial state
+  channels: [],
+  selectedChannel: null,
+  selectedChannelListId: null,
+  channelLists: [],
+  filteredChannels: [],
+  
+  // Actions
+  setChannels: (channels) => set({ channels }),
+  setSelectedChannel: (channel) => set({ selectedChannel: channel }),
+  setSelectedChannelListId: (id) => set({ selectedChannelListId: id }),
+  setChannelLists: (lists) => set({ channelLists: lists }),
+  setFilteredChannels: (channels) => set({ filteredChannels: channels }),
+  
+  // Async actions
+  fetchChannels: async (id = null) => {
+    const fetchedChannels = await invoke<Channel[]>('get_channels', { id });
+    set({ channels: fetchedChannels });
+  },
+  
+  fetchChannelLists: async () => {
+    const lists = await invoke<ChannelList[]>('get_channel_lists');
+    set({ channelLists: lists });
+  },
+  
+  loadDefaultChannelList: async () => {
+    const lists = await invoke<ChannelList[]>('get_channel_lists');
+    const defaultList = lists.find(list => list.is_default);
+    if (defaultList && get().selectedChannelListId === null) {
+      set({ selectedChannelListId: defaultList.id });
+    }
+  },
+  
+  syncGroupsForChannelList: async (channelListId, allGroups) => {
+    await invoke('sync_channel_list_groups', { channelListId, groups: allGroups });
+  },
+}));
+
+export default useChannelStore;

--- a/src/stores/filtersStore.ts
+++ b/src/stores/filtersStore.ts
@@ -1,0 +1,87 @@
+import { create } from 'zustand';
+import { invoke } from '@tauri-apps/api/core';
+
+export interface SavedFilter {
+  id: number;
+  channel_list_id: number;
+  search_query: string;
+  selected_group: string | null;
+  name: string;
+  slot_number: number;
+}
+
+interface FiltersState {
+  // State
+  savedFilters: SavedFilter[];
+  
+  // Actions
+  setSavedFilters: (filters: SavedFilter[]) => void;
+  
+  // Async actions
+  fetchFilters: (channelListId: number | null) => Promise<void>;
+  saveFilter: (
+    channelListId: number,
+    slotNumber: number,
+    searchQuery: string,
+    selectedGroup: string | null,
+    name: string
+  ) => Promise<boolean>;
+  deleteFilter: (id: number) => Promise<boolean>;
+}
+
+const useFiltersStore = create<FiltersState>((set) => ({
+  // Initial state
+  savedFilters: [],
+  
+  // Actions
+  setSavedFilters: (filters) => set({ savedFilters: filters }),
+  
+  // Async actions
+  fetchFilters: async (channelListId) => {
+    if (channelListId === null) {
+      set({ savedFilters: [] });
+      return;
+    }
+    
+    try {
+      const filters = await invoke<SavedFilter[]>('get_saved_filters', { channelListId });
+      set({ savedFilters: filters });
+    } catch (error) {
+      console.error('Failed to fetch saved filters:', error);
+      set({ savedFilters: [] });
+    }
+  },
+  
+  saveFilter: async (channelListId, slotNumber, searchQuery, selectedGroup, name) => {
+    try {
+      await invoke('save_filter', {
+        channelListId,
+        slotNumber,
+        searchQuery,
+        selectedGroup,
+        name
+      });
+      
+      // Refresh filters after saving
+      const filters = await invoke<SavedFilter[]>('get_saved_filters', { channelListId });
+      set({ savedFilters: filters });
+      
+      return true;
+    } catch (error) {
+      console.error('Failed to save filter:', error);
+      return false;
+    }
+  },
+  
+  deleteFilter: async (id) => {
+    try {
+      await invoke('delete_saved_filter', { id });
+      return true;
+    } catch (error) {
+      console.error('Failed to delete filter:', error);
+      return false;
+    }
+  },
+}));
+
+export default useFiltersStore;

--- a/src/stores/groupStore.ts
+++ b/src/stores/groupStore.ts
@@ -1,0 +1,133 @@
+import { create } from 'zustand';
+import { invoke } from '@tauri-apps/api/core';
+import { GroupDisplayMode } from './uiStore';
+
+interface GroupState {
+  // State
+  groups: string[];
+  selectedGroup: string | null;
+  enabledGroups: Set<string>;
+  groupDisplayMode: GroupDisplayMode;
+  
+  // Actions
+  setGroups: (groups: string[]) => void;
+  setSelectedGroup: (group: string | null) => void;
+  setEnabledGroups: (groups: Set<string>) => void;
+  setGroupDisplayMode: (mode: GroupDisplayMode) => void;
+  
+  // Complex actions
+  toggleGroupEnabled: (groupName: string) => void;
+  selectAllGroups: () => void;
+  unselectAllGroups: () => void;
+  clearGroupFilter: () => void;
+  
+  // Async actions
+  fetchGroups: (id?: number | null) => Promise<void>;
+  fetchEnabledGroups: (channelListId: number) => Promise<string[]>;
+  updateGroupSelection: (channelListId: number, groupName: string, enabled: boolean) => Promise<void>;
+  enableAllGroups: (channelListId: number) => Promise<void>;
+  disableAllGroups: (channelListId: number) => Promise<void>;
+}
+
+const useGroupStore = create<GroupState>((set, get) => ({
+  // Initial state
+  groups: [],
+  selectedGroup: null,
+  enabledGroups: new Set(),
+  groupDisplayMode: GroupDisplayMode.EnabledGroups,
+  
+  // Actions
+  setGroups: (groups) => set({ groups }),
+  setSelectedGroup: (group) => set({ selectedGroup: group }),
+  setEnabledGroups: (groups) => set({ enabledGroups: groups }),
+  setGroupDisplayMode: (mode) => set({ groupDisplayMode: mode }),
+  
+  // Complex actions
+  toggleGroupEnabled: (groupName) => {
+    const { enabledGroups } = get();
+    const newEnabledGroups = new Set(enabledGroups);
+    
+    if (newEnabledGroups.has(groupName)) {
+      newEnabledGroups.delete(groupName);
+    } else {
+      newEnabledGroups.add(groupName);
+    }
+    
+    set({ enabledGroups: newEnabledGroups });
+  },
+  
+  selectAllGroups: () => {
+    const { groups } = get();
+    set({ enabledGroups: new Set(groups) });
+  },
+  
+  unselectAllGroups: () => {
+    set({ enabledGroups: new Set() });
+  },
+  
+  clearGroupFilter: () => {
+    set({ 
+      selectedGroup: null,
+      groupDisplayMode: GroupDisplayMode.EnabledGroups 
+    });
+  },
+  
+  // Async actions
+  fetchGroups: async (id = null) => {
+    const fetchedGroups = await invoke<string[]>('get_groups', { id });
+    set({ groups: fetchedGroups });
+  },
+  
+  fetchEnabledGroups: async (channelListId) => {
+    const fetchedEnabledGroups = await invoke<string[]>('get_enabled_groups', { channelListId });
+    set({ enabledGroups: new Set(fetchedEnabledGroups) });
+    return fetchedEnabledGroups;
+  },
+  
+  updateGroupSelection: async (channelListId, groupName, enabled) => {
+    await invoke('update_group_selection', {
+      channelListId,
+      groupName,
+      enabled
+    });
+    
+    // Update local state
+    const { enabledGroups } = get();
+    const newEnabledGroups = new Set(enabledGroups);
+    
+    if (enabled) {
+      newEnabledGroups.add(groupName);
+    } else {
+      newEnabledGroups.delete(groupName);
+    }
+    
+    set({ enabledGroups: newEnabledGroups });
+  },
+  
+  enableAllGroups: async (channelListId) => {
+    const { groups } = get();
+    await invoke('enable_all_groups', {
+      channelListId,
+      groups
+    });
+    set({ enabledGroups: new Set(groups) });
+  },
+  
+  disableAllGroups: async (channelListId) => {
+    const { groups, enabledGroups } = get();
+    
+    for (const group of groups) {
+      if (enabledGroups.has(group)) {
+        await invoke('update_group_selection', {
+          channelListId,
+          groupName: group,
+          enabled: false
+        });
+      }
+    }
+    
+    set({ enabledGroups: new Set() });
+  },
+}));
+
+export default useGroupStore;

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,0 +1,6 @@
+export { default as useChannelStore } from './channelStore';
+export { default as useUIStore, GroupDisplayMode } from './uiStore';
+export { default as useGroupStore } from './groupStore';
+export { default as useUserDataStore } from './userDataStore';
+export { default as useVideoPlayerStore } from './videoPlayerStore';
+export { default as useFiltersStore, type SavedFilter } from './filtersStore';

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -1,0 +1,61 @@
+import { create } from 'zustand';
+import type { Tab } from '../components/NavigationSidebar';
+
+export enum GroupDisplayMode {
+  EnabledGroups = 'enabled',
+  AllGroups = 'all'
+}
+
+interface UIState {
+  // Navigation state
+  activeTab: Tab;
+  focusedIndex: number;
+  
+  // Loading states
+  isLoadingChannelList: boolean;
+  skipSearchEffect: boolean;
+  
+  // Search state
+  searchQuery: string;
+  debouncedSearchQuery: string;
+  isSearching: boolean;
+  
+  // Actions
+  setActiveTab: (tab: Tab) => void;
+  setFocusedIndex: (index: number) => void;
+  setIsLoadingChannelList: (loading: boolean) => void;
+  setSkipSearchEffect: (skip: boolean) => void;
+  setSearchQuery: (query: string) => void;
+  setDebouncedSearchQuery: (query: string) => void;
+  setIsSearching: (searching: boolean) => void;
+  resetUIState: () => void;
+}
+
+const useUIStore = create<UIState>((set) => ({
+  // Initial state
+  activeTab: 'channels',
+  focusedIndex: 0,
+  isLoadingChannelList: false,
+  skipSearchEffect: false,
+  searchQuery: '',
+  debouncedSearchQuery: '',
+  isSearching: false,
+  
+  // Actions
+  setActiveTab: (tab) => set({ activeTab: tab }),
+  setFocusedIndex: (index) => set({ focusedIndex: index }),
+  setIsLoadingChannelList: (loading) => set({ isLoadingChannelList: loading }),
+  setSkipSearchEffect: (skip) => set({ skipSearchEffect: skip }),
+  setSearchQuery: (query) => set({ searchQuery: query }),
+  setDebouncedSearchQuery: (query) => set({ debouncedSearchQuery: query }),
+  setIsSearching: (searching) => set({ isSearching: searching }),
+  
+  resetUIState: () => set({
+    focusedIndex: 0,
+    searchQuery: '',
+    debouncedSearchQuery: '',
+    isSearching: false,
+  }),
+}));
+
+export default useUIStore;

--- a/src/stores/userDataStore.ts
+++ b/src/stores/userDataStore.ts
@@ -1,0 +1,62 @@
+import { create } from 'zustand';
+import { invoke } from '@tauri-apps/api/core';
+import type { Channel } from '../components/ChannelList';
+
+interface UserDataState {
+  // State
+  favorites: Channel[];
+  history: Channel[];
+  
+  // Actions
+  setFavorites: (favorites: Channel[]) => void;
+  setHistory: (history: Channel[]) => void;
+  
+  // Async actions
+  fetchFavorites: () => Promise<void>;
+  fetchHistory: () => Promise<void>;
+  toggleFavorite: (channel: Channel) => Promise<void>;
+  addToHistory: (channel: Channel) => Promise<void>;
+}
+
+const useUserDataStore = create<UserDataState>((set, get) => ({
+  // Initial state
+  favorites: [],
+  history: [],
+  
+  // Actions
+  setFavorites: (favorites) => set({ favorites }),
+  setHistory: (history) => set({ history }),
+  
+  // Async actions
+  fetchFavorites: async () => {
+    const fetchedFavorites = await invoke<Channel[]>('get_favorites');
+    set({ favorites: fetchedFavorites });
+  },
+  
+  fetchHistory: async () => {
+    const fetchedHistory = await invoke<Channel[]>('get_history');
+    set({ history: fetchedHistory });
+  },
+  
+  toggleFavorite: async (channel) => {
+    const { favorites } = get();
+    const isFavorite = favorites.some((fav) => fav.name === channel.name);
+    
+    if (isFavorite) {
+      await invoke('remove_favorite', { name: channel.name });
+    } else {
+      await invoke('add_favorite', { channel });
+    }
+    
+    // Refresh favorites after toggling
+    await get().fetchFavorites();
+  },
+  
+  addToHistory: async (channel) => {
+    await invoke('play_channel', { channel });
+    // Refresh history after adding
+    await get().fetchHistory();
+  },
+}));
+
+export default useUserDataStore;

--- a/src/stores/videoPlayerStore.ts
+++ b/src/stores/videoPlayerStore.ts
@@ -1,0 +1,48 @@
+import { create } from 'zustand';
+import { RefObject } from 'react';
+import Hls from 'hls.js';
+
+interface VideoPlayerState {
+  // State
+  videoRef: RefObject<HTMLVideoElement> | null;
+  hlsInstance: Hls | null;
+  
+  // Actions
+  setVideoRef: (ref: RefObject<HTMLVideoElement>) => void;
+  setHlsInstance: (hls: Hls | null) => void;
+  cleanupVideo: () => void;
+}
+
+const useVideoPlayerStore = create<VideoPlayerState>((set, get) => ({
+  // Initial state
+  videoRef: null,
+  hlsInstance: null,
+  
+  // Actions
+  setVideoRef: (ref) => set({ videoRef: ref }),
+  
+  setHlsInstance: (hls) => {
+    // Cleanup previous instance if exists
+    const { hlsInstance } = get();
+    if (hlsInstance) {
+      hlsInstance.destroy();
+    }
+    set({ hlsInstance: hls });
+  },
+  
+  cleanupVideo: () => {
+    const { videoRef, hlsInstance } = get();
+    
+    if (videoRef?.current) {
+      videoRef.current.pause();
+      videoRef.current.src = '';
+    }
+    
+    if (hlsInstance) {
+      hlsInstance.destroy();
+      set({ hlsInstance: null });
+    }
+  },
+}));
+
+export default useVideoPlayerStore;


### PR DESCRIPTION
Implement Zustand state management to centralize state, eliminate prop drilling, and improve maintainability.

This refactor introduces a `stores` directory with domain-specific Zustand stores (e.g., `channelStore`, `uiStore`, `groupStore`, `userDataStore`, `videoPlayerStore`, `filtersStore`). Components like `App.tsx`, `MainContent`, `NavigationSidebar`, and `ChannelDetails` now consume state directly from these stores, significantly reducing prop drilling (e.g., `MainContent` props reduced from 24 to 0). All existing functionality, TypeScript types, and API calls are preserved, resulting in cleaner, more maintainable components.